### PR TITLE
Different radices

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,11 @@ fn parse_options() -> wires::Options {
                             .help("The file to get strings out of")
                             .required(true)
                             .index(1))
-                        //TODO actually accept offset radices besides hex
-                        .arg(Arg::with_name("offset")
+                        .arg(Arg::with_name("radix")
                             .short("t")
                             .long("radix")
                             .help("Print offset where strings occur?")
+                            .takes_value(true)
                             .required(false))
                         .arg(Arg::with_name("bytes")
                             .short("n")
@@ -27,7 +27,8 @@ fn parse_options() -> wires::Options {
                         .get_matches(); 
 
     let path = matches.value_of("FILE").expect("Please provide a path");
-    let print_offset = matches.is_present("offset");
+    let option_radix = matches.value_of("radix");
+    let radix = wires::string_to_offset_radix(option_radix).expect("Invalid offset radix specified");
 
     let option_bytes = matches.value_of("bytes");
     let mut bytes = 3usize; 
@@ -39,7 +40,7 @@ fn parse_options() -> wires::Options {
     }
 
     wires::Options { 
-        print_offset: print_offset, 
+        print_offset: radix, 
         match_length: bytes,
         path: path.to_string()
     }

--- a/src/wires.rs
+++ b/src/wires.rs
@@ -10,6 +10,26 @@ pub struct Options {
    pub path: String
 }
 
+pub enum OffsetRadix {
+    None,
+    Hex,
+    Octal,
+    Decimal
+}
+
+pub fn string_to_offset_radix(input: Option<&str>) -> Result<OffsetRadix, ()> {
+    match input{
+        Some(string) => match string {
+            "x" => Ok(OffsetRadix::Hex),
+            "o" => Ok(OffsetRadix::Hex),
+            "d" => Ok(OffsetRadix::Decimal),
+            _ => Err(())
+        },
+        None => Ok(OffsetRadix::None)
+    }
+
+}
+
 pub fn bytes_to_strings<W: Write>(bytes: &[u8], w:  &mut W, opts: &Options) {
     let min_consecutive_chars = opts.match_length;
     let mut current_bytes : Vec<u8> = Vec::new(); 

--- a/src/wires.rs
+++ b/src/wires.rs
@@ -3,13 +3,13 @@ use std::ascii::AsciiExt;
 use std::str;
 use std::fmt;
 
-#[derive(Debug)]
 pub struct Options {
-   pub print_offset: bool,
+   pub print_offset: OffsetRadix,
    pub match_length: usize,
    pub path: String
 }
 
+#[derive(Clone, Copy)]
 pub enum OffsetRadix {
     None,
     Hex,
@@ -21,7 +21,7 @@ pub fn string_to_offset_radix(input: Option<&str>) -> Result<OffsetRadix, ()> {
     match input{
         Some(string) => match string {
             "x" => Ok(OffsetRadix::Hex),
-            "o" => Ok(OffsetRadix::Hex),
+            "o" => Ok(OffsetRadix::Octal),
             "d" => Ok(OffsetRadix::Decimal),
             _ => Err(())
         },
@@ -52,7 +52,7 @@ pub fn bytes_to_strings<W: Write>(bytes: &[u8], w:  &mut W, opts: &Options) {
                 }
             }
             current_bytes.truncate(0);
-            offset = offset + 1; 
+            offset = offset + 1;
         }
     }
     if current_bytes.len() >= min_consecutive_chars {
@@ -67,11 +67,15 @@ pub fn bytes_to_strings<W: Write>(bytes: &[u8], w:  &mut W, opts: &Options) {
     }
 }
 
-fn offset_string(offset: usize, print_offset: bool) -> String {
-    let mut output = "".to_string();   
-    if print_offset {
-        fmt::write(&mut output, format_args!("0x{:X}: ", offset)).unwrap();
+fn offset_string(offset: usize, radix: OffsetRadix) -> String {
+    let mut output = "".to_string();
+    match radix {
+        OffsetRadix::Hex => fmt::write(&mut output, format_args!("0x{:X}: ", offset)).unwrap(),
+        OffsetRadix::Octal => fmt::write(&mut output, format_args!("0o{:o}: ", offset)).unwrap(),
+        OffsetRadix::Decimal => fmt::write(&mut output, format_args!("{}: ", offset)).unwrap(),
+        OffsetRadix::None => ()
     }
+
     output
 }
 
@@ -84,15 +88,15 @@ fn it_writes_to_the_buffer() {
     use std::io::Cursor;
 
     let opts = Options {
-        print_offset: false,
+        print_offset: OffsetRadix::None,
         match_length: 3,
         path: "".to_string()
     };
 
-    let mut cursor = Cursor::new(Vec::new()); 
+    let mut cursor = Cursor::new(Vec::new());
     bytes_to_strings("hello".as_bytes(), &mut cursor, &opts);
     let expected = "hello\n";
-    let vec = cursor.into_inner(); 
+    let vec = cursor.into_inner();
     let actual = String::from_utf8(vec).unwrap();
     assert_eq!(expected, actual);
 }
@@ -103,7 +107,7 @@ fn it_omits_intermediate_nonsense() {
     let mut cursor = Cursor::new(Vec::new());
 
     let opts = Options {
-        print_offset: false,
+        print_offset: OffsetRadix::None,
         match_length: 3,
         path: "".to_string()
     };


### PR DESCRIPTION
Accept different offset radices.

`wires -t x file` will print offsets in hex, for example. 